### PR TITLE
awsの使用量予算アラートをterraformを使ってemailにメッセージがいくようにしました。

### DIFF
--- a/budget_alert.tf
+++ b/budget_alert.tf
@@ -1,10 +1,10 @@
 resource "aws_sns_topic" "budget_alert" {
-  provider = aws.us
+  provider = aws.virginia
   name     = "budget-alert-topic"
 }
 
 resource "aws_sns_topic_subscription" "email" {
-  provider  = aws.us
+  provider  = aws.virginia
   topic_arn = aws_sns_topic.budget_alert.arn
   protocol  = "email"
   endpoint  = "riku.yanagihashi0420@gmail.com"
@@ -20,7 +20,7 @@ locals {
 
 
 resource "aws_budgets_budget" "budget" {
-  provider         = aws.us
+  provider         = aws.virginia
   for_each         = { for b in local.budget_levels : b.name => b }
   name             = each.value.name
   budget_type      = "COST"

--- a/budget_alert.tf
+++ b/budget_alert.tf
@@ -1,0 +1,38 @@
+resource "aws_sns_topic" "budget_alert" {
+  provider = aws.us
+  name     = "budget-alert-topic"
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  provider  = aws.us
+  topic_arn = aws_sns_topic.budget_alert.arn
+  protocol  = "email"
+  endpoint  = "riku.yanagihashi0420@gmail.com"
+}
+
+locals {
+  budget_levels = [
+    { name = "budget-1", amount = 1 },
+    { name = "budget-5", amount = 5 },
+    { name = "budget-10", amount = 10 }
+  ]
+}
+
+
+resource "aws_budgets_budget" "budget" {
+  provider         = aws.us
+  for_each         = { for b in local.budget_levels : b.name => b }
+  name             = each.value.name
+  budget_type      = "COST"
+  time_unit        = "MONTHLY"
+  limit_amount     = each.value.amount
+  limit_unit       = "USD"
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.budget_alert.arn]
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0, < 2.0.0"
+
+  backend "s3" {
+    bucket = "kdg-aws-2025-yanagihashi"      
+    key    = "terraform/state.tfstate"       
+    region = "ap-northeast-1"                 #  東
+    encrypt = true                            
+  }
+}
+
+provider "aws" {
+  alias  = "us"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  region = "ap-northeast-1"  # ←デフォルトは東京
+}

--- a/versions.tf
+++ b/versions.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  alias  = "us"
+  alias  = "virginia"
   region = "us-east-1"
 }
 

--- a/手順.md
+++ b/手順.md
@@ -1,0 +1,10 @@
+# これの実行の仕方
+```
+terraform init
+terraform plan
+terraform apply
+
+```
+
+awsでメッセージを発行したら設定したemailにメッセージが行く
+それで成功


### PR DESCRIPTION

<img width="1184" alt="Screenshot 2025-06-07 at 14 45 19" src="https://github.com/user-attachments/assets/4e54a2e7-5dc2-43b6-8276-edd3804b60cc" />
<img width="1470" alt="Screenshot 2025-06-07 at 13 33 47" src="https://github.com/user-attachments/assets/581fcb1e-6920-4674-a3e4-e02ad39cf562" />
<img width="1461" alt="Screenshot 2025-06-07 at 13 33 42" src="https://github.com/user-attachments/assets/b1322b56-51b3-449d-b1c6-a36ab02848e4" />

Simple Notification Serviceを使っているので、
そこでトピックを生成してメッセージの発行を行うと設定されているメッセージに送られます。
applyした時点ではメッセージの発行が行われないです。(購読メッセージは来るかもしれないです)

## 見て欲しいところ
- regionのところが少し特殊なやり方で実装していると思っているのでそこの確認
- aws自体に料金が発生していないので、そのアラートのテスト方法がわからないのでそこの確認、またはテスト方法を教えてくれるよ嬉しいてす